### PR TITLE
Accept directly specified resource directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ installer-cli -i path/to/electron/app -k path/to/kernel
 
 The `-i` flag specifies the path to the Electron app to inject into.
 
-It should be the path to the directory above the `resources` folder.
+It should be the path to the directory above the `resources` folder (or the '`resources`' folder itself, because of cases like discord\_arch\_electron/discord-canary-electron-bin on the AUR, which place the contents of the `resources` folder into `/usr/lib/discord` and `/usr/lib/discord-canary` respectively).
 
 For example on Windows for Discord: `C:/Users/Kyza/AppData/Local/Discord/app-XXXX/`
 

--- a/gyro.lock
+++ b/gyro.lock
@@ -1,3 +1,1 @@
-github Hejsil zig-clap master clap.zig 4be3fcdb616647215dc162c9e2f64b7d6e3ad09d
-github Hejsil zig-clap zig-master clap.zig 27899f951e94a67bf68d6dfebbf4ab9cf182d896
-github Kyza zig-clap zig-master clap.zig 668012cce24355606f712b182ded99730c496d03
+git https://github.com/Hejsil/zig-clap.git zig-master clap.zig cf8a34d11f0520bdf2afc08eda88862597a88b23

--- a/gyro.zzz
+++ b/gyro.zzz
@@ -1,8 +1,6 @@
 deps:
   clap:
-    src:
-      github:
-        user: Kyza
-        repo: zig-clap
-        ref: zig-master
-    root: clap.zig
+    git:
+      url: "https://github.com/Hejsil/zig-clap.git"
+      ref: zig-master
+      root: clap.zig

--- a/src/main.zig
+++ b/src/main.zig
@@ -43,7 +43,13 @@ pub fn main() !void {
          const kernel_path = try fs.path.resolve(allocator, &[_][]const u8{ kernel });
 
          const app_path = try fs.path.resolve(allocator, &[_][]const u8{ inject });
-         const resources_path = try fs.path.join(allocator, &[_][]const u8{ app_path, "resources" });
+
+         var resources_path = try fs.path.join(allocator, &[_][]const u8{ app_path, "resources" });
+
+         // Test if the folder is (probably) either a valid electron app path or an app resources path.
+         _ = fs.openDirAbsolute(resources_path, .{}) catch {
+            resources_path = app_path;
+         };
 
          const app_folder_path = try fs.path.join(allocator, &[_][]const u8{ resources_path, "app" });
          const app_asar_path = try fs.path.join(allocator, &[_][]const u8{ resources_path, "app.asar" });
@@ -53,9 +59,6 @@ pub fn main() !void {
 
          const app_original_folder_path = try fs.path.join(allocator, &[_][]const u8{ resources_path, "app-original" });
          const app_original_asar_path = try fs.path.join(allocator, &[_][]const u8{ resources_path, "app-original.asar" });
-
-         // Test if the folder is (probably) a valid Electron app.
-         _ = fs.openDirAbsolute(resources_path, .{}) catch invalidAppDir();
 
          debug.print("Detecting injection...\n", .{});
          var injected = true;


### PR DESCRIPTION
Reasoning:
Cases like `discord_arch_electron` or `discord-canary-electron-bin` on the
AUR. These place the contents of what should be the resources directory
into `/usr/lib/discord` and `/usr/lib/discord-canary` respectively, causing
you to have to make modifications to the installation directory in order
for the installer to inject properly (moving everything in the
installation directory into a newly created 'resources' directory,
running the installer, and moving everything back). This change lets you
specify the 'resources' directory directly, so that modifications are
not necessary.